### PR TITLE
feat: 增加特殊地名和特殊身份

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { Context, Schema, Random } from 'koishi'
-import { regions, locations, identities } from './list'
+import { regions, locations, specialLocations, getSpecialIdentities } from './list'
 
 export const name = 'remake-life'
 
@@ -8,11 +8,21 @@ export interface Config { }
 export const Config: Schema<Config> = Schema.object({})
 
 export function apply(ctx: Context) {
-  ctx.command('remake', '重开你的人生').action(({ session }) => {
+  ctx.command('remake', '重开你的人生')
+     .alias("重开")
+     .action(({ session }) => {
     const region = Random.pick(regions)
     if (region) {
-      const location = Random.pick(locations)
-      const identity = Random.pick(identities)
+      let location: string
+      let identity: string
+      if(Object.keys(specialLocations).includes(region)) {
+        location = Random.pick(specialLocations[region])
+      } else {
+        location = Random.pick(locations)
+      }
+
+      identity = Random.pick(getSpecialIdentities(location))
+
       return `<quote id="${session.messageId}"/>重开成功！你出生在<b>${region}</b>的<b>${location}</b>，是<b>${identity}</b>！`
     }
     return `<quote id="${session.messageId}"/>重开失败！你没能出生！`

--- a/src/list.ts
+++ b/src/list.ts
@@ -1,5 +1,35 @@
-export const regions = [null, '法国', '中国', '德国', '加拿大', '缅甸', '日本', '英国', '美国', '韩国', '朝鲜', '印度', '西班牙', '巴西', '冰岛', '挪威', '丹麦', '瑞典', '芬兰']
+export const regions = [null, '法国', '中国', '德国', '加拿大', '缅甸', '日本', '英国', '美国', '韩国', '朝鲜', '印度', '西班牙', '巴西', '冰岛', '挪威', '丹麦', '瑞典', '芬兰', '交界地']
 
 export const locations = ['大学', '县城', '首都', '农村', '市区']
 
 export const identities = ['女孩子', '鼠鼠', '鲨鲨', '猫猫', '男孩子', '狗狗', '鸽子', 'xyn']
+
+// 特殊地点
+export const specialLocations = {
+    "日本": ["穗织村", "鹫逗市"],
+    "交界地": ["宁姆格福", "史东薇尔城", "盖利徳"]
+    // 可扩展（笑）
+}
+    
+
+// 特殊身份，通过地点判断，如果匹配不上返回基本的
+export function getSpecialIdentities(location: string) {
+    if(specialLocations["交界地"].includes(location)) {
+        return ["褪色者", "菈妮", "拉塔恩"]
+    } else {
+        switch( location ){
+            case "穗织村":
+                return [
+                    "朝武芳乃", "常陆茉子", "有地将臣", "丛雨", "蕾娜·列支敦瑙尔", 
+                    "鞍马小春", "马庭芦花", "鞍马廉太郎", "鞍马玄十郎"
+                ]
+            case "鹫逗市":
+                return [
+                    "三司绫濑", "在原七海", "二条院羽月", "式部茉优", "壬生千咲", "在原晓",
+                    "周防恭平"
+                ]
+            default:
+                return identities
+        }
+    }
+}


### PR DESCRIPTION
- region增加【交界地】（艾尔登法环）
- 判断region，给特殊region增加特殊地点和特殊身份（穗织村, 鹫逗市地名分别来自柚子社galgame千恋万花和Riddle Joker）
- 身份根据对应地点设定来选取

**例子**：

![2ED8E79AA604EC805F6F39F07C4CAF42](https://github.com/user-attachments/assets/692ffcc7-ed0e-41ac-be60-cda8d4b7033b)
